### PR TITLE
Fix int(11) for mysql

### DIFF
--- a/src/Resolvers/SchemaRulesResolverMySql.php
+++ b/src/Resolvers/SchemaRulesResolverMySql.php
@@ -90,6 +90,12 @@ class SchemaRulesResolverMySql extends BaseSchemaRulesResolver implements Schema
                 $columnRules[] = "integer";
                 $sign = ($type->contains('unsigned')) ? 'unsigned' : 'signed' ;
                 $intType = $type->before(' unsigned')->__toString();
+
+                // prevent int(xx) for mysql
+                if(!array_key_exists($intType, self::$integerTypes)){
+                    $intType = "int";
+                }
+
                 $columnRules[] = "min:".self::$integerTypes[$intType][$sign][0];
                 $columnRules[] = "max:".self::$integerTypes[$intType][$sign][1];
 

--- a/src/Resolvers/SchemaRulesResolverMySql.php
+++ b/src/Resolvers/SchemaRulesResolverMySql.php
@@ -92,6 +92,8 @@ class SchemaRulesResolverMySql extends BaseSchemaRulesResolver implements Schema
                 $intType = $type->before(' unsigned')->__toString();
 
                 // prevent int(xx) for mysql
+                $intType = preg_replace("/\([^)]+\)/", "", $intType);
+
                 if(!array_key_exists($intType, self::$integerTypes)){
                     $intType = "int";
                 }
@@ -115,7 +117,7 @@ class SchemaRulesResolverMySql extends BaseSchemaRulesResolver implements Schema
                 $columnRules[] = 'in:'.implode(',', $matches[1]);
 
                 break;
-            case $type == 'year':
+            case $type->contains('year'):
                 $columnRules[] = 'integer';
                 $columnRules[] = 'min:1901';
                 $columnRules[] = 'max:2155';


### PR DESCRIPTION
Mysql has int(11) column that doesnt match with int types: defaulted to default int if not matched.
Same issue with year that becomes `year(4)`