### PR TITLE
add default [] for schema-rules.skip_columns to prevent errors when config is not published.

### DIFF
--- a/src/Exceptions/ColumnDoesNotExistException.php
+++ b/src/Exceptions/ColumnDoesNotExistException.php
@@ -4,6 +4,4 @@ namespace LaracraftTech\LaravelSchemaRules\Exceptions;
 
 use Exception;
 
-class ColumnDoesNotExistException extends Exception
-{
-}
+class ColumnDoesNotExistException extends Exception {}

--- a/src/Exceptions/MultipleTablesSuppliedException.php
+++ b/src/Exceptions/MultipleTablesSuppliedException.php
@@ -4,6 +4,4 @@ namespace LaracraftTech\LaravelSchemaRules\Exceptions;
 
 use Exception;
 
-class MultipleTablesSuppliedException extends Exception
-{
-}
+class MultipleTablesSuppliedException extends Exception {}

--- a/src/Exceptions/TableDoesNotExistException.php
+++ b/src/Exceptions/TableDoesNotExistException.php
@@ -4,6 +4,4 @@ namespace LaracraftTech\LaravelSchemaRules\Exceptions;
 
 use Exception;
 
-class TableDoesNotExistException extends Exception
-{
-}
+class TableDoesNotExistException extends Exception {}

--- a/src/Exceptions/UnsupportedDbDriverException.php
+++ b/src/Exceptions/UnsupportedDbDriverException.php
@@ -4,6 +4,4 @@ namespace LaracraftTech\LaravelSchemaRules\Exceptions;
 
 use Exception;
 
-class UnsupportedDbDriverException extends Exception
-{
-}
+class UnsupportedDbDriverException extends Exception {}

--- a/src/Resolvers/BaseSchemaRulesResolver.php
+++ b/src/Resolvers/BaseSchemaRulesResolver.php
@@ -21,7 +21,7 @@ abstract class BaseSchemaRulesResolver implements SchemaRulesResolverInterface
     {
         $tableColumns = $this->getColumnsDefinitionsFromTable();
 
-        $skip_columns = config('schema-rules.skip_columns');
+        $skip_columns = config('schema-rules.skip_columns', []);
 
         $tableRules = [];
         foreach ($tableColumns as $column) {


### PR DESCRIPTION
I'm trying to use this package as a dependency and noticed my tests were failing because the config hadn't been published. Thea reason was the skip_columns value was NULL. This should fix that and seems like a sensible default.